### PR TITLE
ANDAUTH-25  Add Material buttons in Sign up/ Sign In layouts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "$rootProject.buildToolsVersion"
- configurations.all {
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
+    configurations.all {
         resolutionStrategy {
             force 'com.android.support:support-annotations:24.2.1'
         }
     }
     defaultConfig {
         applicationId "org.xwiki.android.authenticator"
-        minSdkVersion "$rootProject.minSdkVersion"
-        targetSdkVersion "$rootProject.targetSdkVersion"
+        minSdkVersion 16
+        targetSdkVersion 26
         versionCode 25
         versionName "0.3.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -25,15 +25,17 @@ android {
     lintOptions {
         abortOnError false
     }
-
+    productFlavors {
+    }
 }
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.android.support:appcompat-v7:24.2.1"
-    compile "com.android.support:design:24.2.1"
+    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.android.support:design:26.0.2'
+
     //Square dependencies
-    compile ("com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion") {
+    compile("com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion") {
         // exclude Retrofit’s OkHttp peer-dependency module and define your own module import
         exclude module: 'okhttp'
     }
@@ -41,33 +43,49 @@ dependencies {
     compile "com.squareup.retrofit2:adapter-rxjava:$rootProject.retrofitVersion"
     compile "com.squareup.okhttp3:okhttp:$rootProject.okHttp3Version"
     compile "com.squareup.okhttp3:logging-interceptor:$rootProject.okHttp3Version"
+
     //rxjava Dependencies
     compile 'io.reactivex:rxandroid:1.1.0'
     compile 'io.reactivex:rxjava:1.1.4'
+
     //Butter Knife
     compile "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"
     compile "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
+
     // For getting the from token in the process of sign up
     compile 'org.jsoup:jsoup:1.9.1'
+
     // For Local Unit Tests
+
     // Required -- JUnit 4 framework
     testCompile 'junit:junit:4.12'
+
     // Part of Instrumented Tests or Local Test
+
     // Optional -- Mockito framework
     testCompile 'org.mockito:mockito-core:1.+'
+
     // Optional -- Robolectric library
+
     //testCompile "org.robolectric:robolectric:3.0"
+
     // For android test support (it depends on emulator)
     androidTestCompile "com.android.support:support-annotations:$rootProject.supportLibraryVersion"
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
+
     // Optional -- Hamcrest library
+
     //androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+
     // Optional -- Robotium library
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.5.4'
+
     // Optional -- UI testing with Espresso
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+
     // Optional -- UI testing with UI Automator
+
     //androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v23:2.1.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     //Butter Knife
     compile "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"
     compile "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
+    annotationProcessor "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
     // For getting the from token in the process of sign up
     compile 'org.jsoup:jsoup:1.9.1'
     // For Local Unit Tests

--- a/app/src/main/java/org/xwiki/android/authenticator/auth/AuthenticatorActivity.java
+++ b/app/src/main/java/org/xwiki/android/authenticator/auth/AuthenticatorActivity.java
@@ -24,12 +24,14 @@ import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.Toolbar;
@@ -82,7 +84,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
     private SignUpStep2ViewFlipper signUpStep2ViewFlipper;
 
     private AccountManager mAccountManager;
-
+    AlertDialog.Builder builder;
     private ViewFlipper mViewFlipper;
     private Toolbar toolbar;
     //refresh ImageView mainly in SettingSyncViewFlipper
@@ -116,7 +118,20 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
                 }
             }
         });
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            builder = new AlertDialog.Builder(AuthenticatorActivity.this, android.R.style.Theme_DeviceDefault_Light_Dialog_Alert);
+        } else {
+            builder = new AlertDialog.Builder(AuthenticatorActivity.this);
+        }
+        builder.setTitle("XWiki")
+                .setIcon(getResources().getDrawable(R.drawable.logo))
+                .setMessage("Create XWiki Account to enjoy features like synchronization of contacts and provide credentials for other android apps" )
+                .setPositiveButton("CLOSE", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
         mViewFlipper = (ViewFlipper) findViewById(R.id.view_flipper);
         boolean is_set_sync = getIntent().getBooleanExtra(AuthenticatorActivity.IS_SETTING_SYNC_TYPE, true);
         if (is_set_sync) {
@@ -134,7 +149,12 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
             }
         }
     }
-
+    @Override
+    public void onBackPressed() {
+        if(mViewFlipper.getDisplayedChild()==ViewFlipperLayoutId.SETTING_IP)
+            super.onBackPressed();
+        doPreviousNext(false);
+    }
 
     @Override
     protected void onDestroy() {
@@ -232,12 +252,16 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
         doPreviousNext(true);
     }
 
-    public void setLeftRightButton(String leftButton, String rightButton) {
-        ((Button) findViewById(R.id.left_button)).setText(leftButton);
-        ((Button) findViewById(R.id.right_button)).setText(rightButton);
+
+
+    public void next(View view) {
+        AlertDialog dialog=builder.create();
+        dialog.show();
     }
-
-
+    public void signUp(View view)
+    {
+        showViewFlipper(ViewFlipperLayoutId.SIGN_UP_STEP1);
+    }
     public interface ViewFlipperLayoutId {
         int SETTING_IP = 0;
         int SIGN_IN = 1;
@@ -256,14 +280,14 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
                     settingsIpViewFlipper = new SettingIpViewFlipper(this, mViewFlipper.getChildAt(id));
                 }
                 toolbar.setTitle("XWiki Account");
-                setLeftRightButton("Sign In", "Sign Up");
+
                 break;
             case ViewFlipperLayoutId.SIGN_IN:
                 if (signInViewFlipper == null) {
                     signInViewFlipper = new SignInViewFlipper(this, mViewFlipper.getChildAt(id));
                 }
                 toolbar.setTitle("Sign In");
-                setLeftRightButton("Previous", "Login");
+
                 break;
             case ViewFlipperLayoutId.SETTING_SYNC:
                 refreshImageView.setVisibility(View.VISIBLE);
@@ -271,14 +295,14 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
                     settingSyncViewFlipper = new SettingSyncViewFlipper(this, mViewFlipper.getChildAt(id));
                 }
                 toolbar.setTitle("Setting Sync");
-                setLeftRightButton("Cancel", "Complete");
+
                 break;
             case ViewFlipperLayoutId.SIGN_UP_STEP1:
                 if (signUpStep1ViewFlipper == null) {
                     signUpStep1ViewFlipper = new SignUpStep1ViewFlipper(this, mViewFlipper.getChildAt(id));
                 }
                 toolbar.setTitle("Sign Up Step1");
-                setLeftRightButton("Previous", "Next");
+
                 break;
             case ViewFlipperLayoutId.SIGN_UP_STEP2:
                 refreshImageView.setVisibility(View.VISIBLE);
@@ -286,7 +310,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorActivity{
                     signUpStep2ViewFlipper = new SignUpStep2ViewFlipper(this, mViewFlipper.getChildAt(id));
                 }
                 toolbar.setTitle("Sign Up Step2");
-                setLeftRightButton("Previous", "Register");
+
                 break;
         }
     }

--- a/app/src/main/res/layout/act_authenticator.xml
+++ b/app/src/main/res/layout/act_authenticator.xml
@@ -62,40 +62,4 @@
 
     </ViewFlipper>
 
-    <LinearLayout
-        android:id="@+id/left_right_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:minHeight="54dip"
-        android:orientation="horizontal"
-        android:paddingBottom="5dip"
-        android:paddingLeft="10dip"
-        android:paddingRight="10dip">
-
-        <Button
-            android:id="@+id/left_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_weight="1"
-            android:minWidth="100dip"
-            android:onClick="doPrevious"
-            android:paddingRight="10dp"
-            android:text="@string/login_activity_ok_button"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <Button
-            android:id="@+id/right_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_weight="1"
-            android:minWidth="100dip"
-            android:onClick="doNext"
-            android:paddingLeft="10dp"
-            android:text="@string/login_activity_register_button"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-    </LinearLayout>
-
 </RelativeLayout>

--- a/app/src/main/res/layout/act_edit_contact.xml
+++ b/app/src/main/res/layout/act_edit_contact.xml
@@ -11,9 +11,9 @@
         android:id="@+id/login_form"
         android:layout_width="fill_parent"
         android:layout_height="match_parent"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginLeft="@dimen/scroll_view_margin"
+        android:layout_marginRight="@dimen/scroll_view_margin"
+        android:layout_marginTop="@dimen/scroll_view_margin"
         android:background="@android:color/white"
         android:fillViewport="false">
 
@@ -22,10 +22,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingBottom="13dip"
-            android:paddingLeft="20dip"
-            android:paddingRight="20dip"
-            android:paddingTop="5dip">
+            android:paddingBottom="@dimen/layout_padding_bottom"
+            android:paddingLeft="@dimen/layout_padding_left_right"
+            android:paddingRight="@dimen/layout_padding_left_right"
+            android:paddingTop="@dimen/layout_padding_top">
 
             <TextView
                 android:layout_width="wrap_content"
@@ -41,7 +41,7 @@
                 android:layout_marginBottom="10dp"
                 android:inputType="textPersonName"
                 android:maxLines="1"
-                android:minWidth="250dip"
+                android:minWidth="@dimen/edittext_min_width"
                 android:scrollHorizontally="true"
                 android:textColor="@android:color/black" />
 
@@ -59,7 +59,7 @@
                 android:layout_marginBottom="10dp"
                 android:inputType="text"
                 android:maxLines="1"
-                android:minWidth="250dip"
+                android:minWidth="@dimen/edittext_min_width"
                 android:scrollHorizontally="true"
                 android:textColor="@android:color/black" />
 
@@ -77,7 +77,7 @@
                 android:layout_marginBottom="10dp"
                 android:inputType="phone"
                 android:maxLines="1"
-                android:minWidth="250dip"
+                android:minWidth="@dimen/edittext_min_width"
                 android:scrollHorizontally="true"
                 android:textColor="@android:color/black" />
 
@@ -95,7 +95,7 @@
                 android:layout_marginBottom="10dp"
                 android:inputType="textEmailAddress"
                 android:maxLines="1"
-                android:minWidth="250dip"
+                android:minWidth="@dimen/edittext_min_width"
                 android:scrollHorizontally="true"
                 android:textColor="@android:color/black" />
 

--- a/app/src/main/res/layout/act_grant_permission.xml
+++ b/app/src/main/res/layout/act_grant_permission.xml
@@ -17,10 +17,10 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:paddingBottom="13dip"
-            android:paddingLeft="20dip"
-            android:paddingRight="20dip"
-            android:paddingTop="20dip">
+            android:paddingBottom="@dimen/layout_padding_bottom"
+            android:paddingLeft="@dimen/layout_padding_left_right"
+            android:paddingRight="@dimen/layout_padding_left_right"
+            android:paddingTop="@dimen/layout_padding_top">
 
             <TextView
                 android:id="@+id/message"

--- a/app/src/main/res/layout/viewflipper_setting_ip.xml
+++ b/app/src/main/res/layout/viewflipper_setting_ip.xml
@@ -7,9 +7,9 @@
     <ScrollView
         android:layout_width="fill_parent"
         android:layout_height="match_parent"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginLeft="@dimen/scroll_view_margin"
+        android:layout_marginRight="@dimen/scroll_view_margin"
+        android:layout_marginTop="@dimen/scroll_view_margin"
         android:background="@android:color/white">
 
         <LinearLayout
@@ -17,10 +17,10 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:paddingBottom="13dip"
-            android:paddingLeft="20dip"
-            android:paddingRight="20dip"
-            android:paddingTop="5dip">
+            android:paddingBottom="@dimen/layout_padding_bottom"
+            android:paddingLeft="@dimen/layout_padding_left_right"
+            android:paddingRight="@dimen/layout_padding_left_right"
+            android:paddingTop="@dimen/layout_padding_top">
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -33,13 +33,13 @@
                     android:id="@+id/message"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Login to your XWiki Instance. "
+                    android:text="@string/login_sub_head"
                     android:textStyle="bold"
                     android:textAppearance="?android:attr/textAppearanceSmall" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Learn More"
+                    android:text="@string/learn_more_dialog"
                     android:onClick="next"
                     android:id="@+id/learn_more"
                     android:textColor="@color/primary_dark"/>
@@ -50,7 +50,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/login_activity_server_label"
-                android:textSize="20sp"
+                android:textSize="@dimen/head_text_size"
                 android:layout_marginTop="20dip"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 />
@@ -61,20 +61,20 @@
                 android:layout_height="wrap_content"
                 android:inputType="textEmailAddress"
                 android:maxLines="1"
-                android:minWidth="250dip"
+                android:minWidth="@dimen/edittext_min_width"
                 android:scrollHorizontally="true"
-                android:text="http://www.xwiki.org/xwiki"
+                android:text="@string/server_url"
                 android:textColor="@android:color/black" />
             <Button
                 android:layout_weight="1"
-                android:layout_width="100dp"
-                android:layout_height="50dp"
-                android:text="Next"
-                android:layout_marginTop="20dp"
+                android:layout_width="@dimen/button_width"
+                android:layout_height="@dimen/button_height"
+                android:minHeight="@dimen/button_min_height"
+                android:text="@string/next"
+                android:layout_marginTop="@dimen/button_margin_top"
                 android:onClick="doPrevious"
-                android:textSize="15sp"
-                android:layout_gravity="right"
-                android:backgroundTint="#0077d9"
+                android:layout_gravity="end"
+                android:backgroundTint="@color/next_button_color"
                 android:textColor="@android:color/background_light" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/viewflipper_setting_ip.xml
+++ b/app/src/main/res/layout/viewflipper_setting_ip.xml
@@ -21,21 +21,39 @@
             android:paddingLeft="20dip"
             android:paddingRight="20dip"
             android:paddingTop="5dip">
-
-            <TextView
-                android:id="@+id/message"
+            <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="15dip"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:src="@drawable/xwiki_logo"/>
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+                <TextView
+                    android:id="@+id/message"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Login to your XWiki Instance. "
+                    android:textStyle="bold"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Learn More"
+                    android:onClick="next"
+                    android:id="@+id/learn_more"
+                    android:textColor="@color/primary_dark"/>
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/textView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/login_activity_server_label"
+                android:textSize="20sp"
+                android:layout_marginTop="20dip"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textStyle="bold" />
+                />
 
             <EditText
                 android:id="@+id/accountServer"
@@ -47,6 +65,17 @@
                 android:scrollHorizontally="true"
                 android:text="http://www.xwiki.org/xwiki"
                 android:textColor="@android:color/black" />
+            <Button
+                android:layout_weight="1"
+                android:layout_width="100dp"
+                android:layout_height="50dp"
+                android:text="Next"
+                android:layout_marginTop="20dp"
+                android:onClick="doPrevious"
+                android:textSize="15sp"
+                android:layout_gravity="right"
+                android:backgroundTint="#0077d9"
+                android:textColor="@android:color/background_light" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/viewflipper_settings_sync.xml
+++ b/app/src/main/res/layout/viewflipper_settings_sync.xml
@@ -52,10 +52,24 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/select_spinner"
-        android:layout_marginTop="10dp"
+        android:layout_marginBottom="60dp"
         android:layout_marginLeft="15dp"
         android:layout_marginRight="15dp"
+        android:layout_marginTop="10dp"
         android:divider="#b5b5b5"
         android:dividerHeight="1dp"></ListView>
+
+    <Button
+        android:layout_width="120dp"
+        android:layout_height="50dp"
+        android:layout_alignEnd="@+id/version_check"
+        android:layout_alignParentBottom="true"
+        android:layout_alignRight="@+id/version_check"
+        android:layout_weight="1"
+        android:backgroundTint="#0077d9"
+        android:onClick="doNext"
+        android:text="Complete"
+        android:textColor="@android:color/background_light"
+        android:textSize="15sp" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/viewflipper_settings_sync.xml
+++ b/app/src/main/res/layout/viewflipper_settings_sync.xml
@@ -10,7 +10,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dp"
         android:layout_marginTop="10dp"
-        android:text="About Version"
+        android:text="@string/about_version"
         android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <Button
@@ -23,7 +23,7 @@
         android:gravity="center_vertical"
         android:background="@drawable/button_selector"
         android:layout_marginRight="20dp"
-        android:text="Version 1.0"
+        android:text="@string/version"
         android:textColor="@android:color/black"/>
 
 
@@ -60,16 +60,15 @@
         android:dividerHeight="1dp"></ListView>
 
     <Button
-        android:layout_width="120dp"
+        android:layout_width="@dimen/button_width"
         android:layout_height="50dp"
         android:layout_alignEnd="@+id/version_check"
         android:layout_alignParentBottom="true"
         android:layout_alignRight="@+id/version_check"
-        android:layout_weight="1"
-        android:backgroundTint="#0077d9"
+        android:backgroundTint="@color/next_button_color"
         android:onClick="doNext"
-        android:text="Complete"
+        android:text="@string/complete"
         android:textColor="@android:color/background_light"
-        android:textSize="15sp" />
+        />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/viewflipper_signin.xml
+++ b/app/src/main/res/layout/viewflipper_signin.xml
@@ -17,10 +17,10 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:paddingBottom="13dip"
-            android:paddingLeft="20dip"
-            android:paddingRight="20dip"
-            android:paddingTop="5dip">
+            android:paddingBottom="@dimen/layout_padding_bottom"
+            android:paddingLeft="@dimen/layout_padding_left_right"
+            android:paddingRight="@dimen/layout_padding_left_right"
+            android:paddingTop="@dimen/layout_padding_top">
 
             <ImageView
                 android:layout_width="wrap_content"
@@ -45,7 +45,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/login_activity_username_label"
                     android:inputType="textEmailAddress"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -62,7 +62,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/login_activity_password_label"
                     android:inputType="textPassword"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -74,21 +74,21 @@
                 android:layout_marginTop="10dip"
                 android:gravity="left"
                 android:maxLines="2"
-                android:text="error message"
+                android:text="@string/error_message"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="#e10a0a"
+                android:textColor="@color/error_color"
                 android:textStyle="normal"
                 android:visibility="gone" />
             <Button
                 android:layout_weight="1"
-                android:layout_width="100dp"
-                android:layout_height="50dp"
-                android:text="Log in"
-                android:layout_marginTop="20dp"
+                android:layout_width="@dimen/button_width"
+                android:layout_height="@dimen/button_height"
+                android:minHeight="@dimen/button_min_height"
+                android:text="@string/log_in"
+                android:layout_marginTop="@dimen/button_margin_top"
                 android:onClick="doNext"
-                android:textSize="15sp"
                 android:layout_gravity="center_horizontal"
-                android:backgroundTint="#0077d9"
+                android:backgroundTint="@color/next_button_color"
                 android:textColor="@android:color/background_light" />
             <RelativeLayout
                 android:layout_width="wrap_content"
@@ -100,11 +100,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/dont"
-                    android:text="Don't Have a XWiki Account?" />
+                    android:text="@string/don_t_have_a_account" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text=" Create One"
+                    android:text="@string/create_one"
                     android:onClick="signUp"
                     android:layout_toRightOf="@+id/dont"
                     android:textColor="@color/primary_dark"/>

--- a/app/src/main/res/layout/viewflipper_signin.xml
+++ b/app/src/main/res/layout/viewflipper_signin.xml
@@ -76,11 +76,39 @@
                 android:maxLines="2"
                 android:text="error message"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="@android:color/holo_red_light"
+                android:textColor="#e10a0a"
                 android:textStyle="normal"
                 android:visibility="gone" />
-
-
+            <Button
+                android:layout_weight="1"
+                android:layout_width="100dp"
+                android:layout_height="50dp"
+                android:text="Log in"
+                android:layout_marginTop="20dp"
+                android:onClick="doNext"
+                android:textSize="15sp"
+                android:layout_gravity="center_horizontal"
+                android:backgroundTint="#0077d9"
+                android:textColor="@android:color/background_light" />
+            <RelativeLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:layout_gravity="center_horizontal"
+                android:orientation="horizontal">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/dont"
+                    android:text="Don't Have a XWiki Account?" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=" Create One"
+                    android:onClick="signUp"
+                    android:layout_toRightOf="@+id/dont"
+                    android:textColor="@color/primary_dark"/>
+            </RelativeLayout>
         </LinearLayout>
 
     </ScrollView>

--- a/app/src/main/res/layout/viewflipper_signup_step1.xml
+++ b/app/src/main/res/layout/viewflipper_signup_step1.xml
@@ -19,10 +19,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingBottom="13dip"
-            android:paddingLeft="20dip"
-            android:paddingRight="20dip"
-            android:paddingTop="5dip">
+            android:paddingBottom="@dimen/layout_padding_bottom"
+            android:paddingLeft="@dimen/layout_padding_left_right"
+            android:paddingRight="@dimen/layout_padding_left_right"
+            android:paddingTop="@dimen/layout_padding_top">
 
             <ImageView
                 android:layout_width="wrap_content"
@@ -45,7 +45,7 @@
                     android:hint="@string/first_name"
                     android:inputType="textPersonName"
                     android:maxLines="1"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -64,7 +64,7 @@
                     android:hint="@string/last_name"
                     android:inputType="text"
                     android:maxLines="1"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -72,8 +72,8 @@
             <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:layout_marginTop="8dp">
+                android:layout_marginBottom="@dimen/textinput_margin"
+                android:layout_marginTop="@dimen/textinput_margin">
 
                 <EditText
                     android:id="@+id/email"
@@ -83,7 +83,7 @@
                     android:hint="@string/email"
                     android:inputType="textEmailAddress"
                     android:maxLines="1"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -103,20 +103,20 @@
                 android:layout_marginBottom="10dp"
                 android:inputType="phone"
                 android:maxLines="1"
-                android:minWidth="250dip"
+                android:minWidth="@dimen/edittext_min_width"
                 android:scrollHorizontally="true"
                 android:textColor="@android:color/black"
                 android:visibility="gone" />
             <Button
                 android:layout_weight="1"
-                android:layout_width="100dp"
-                android:layout_height="50dp"
-                android:text="Next"
-                android:layout_marginTop="20dp"
+                android:layout_width="@dimen/button_width"
+                android:layout_height="@dimen/button_height"
+                android:minHeight="@dimen/button_min_height"
+                android:text="@string/next"
+                android:layout_marginTop="@dimen/button_margin_top"
                 android:onClick="doNext"
-                android:textSize="15sp"
-                android:layout_gravity="right"
-                android:backgroundTint="#0077d9"
+                android:layout_gravity="end"
+                android:backgroundTint="@color/next_button_color"
                 android:textColor="@android:color/background_light" />
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/viewflipper_signup_step1.xml
+++ b/app/src/main/res/layout/viewflipper_signup_step1.xml
@@ -107,7 +107,17 @@
                 android:scrollHorizontally="true"
                 android:textColor="@android:color/black"
                 android:visibility="gone" />
-
+            <Button
+                android:layout_weight="1"
+                android:layout_width="100dp"
+                android:layout_height="50dp"
+                android:text="Next"
+                android:layout_marginTop="20dp"
+                android:onClick="doNext"
+                android:textSize="15sp"
+                android:layout_gravity="right"
+                android:backgroundTint="#0077d9"
+                android:textColor="@android:color/background_light" />
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/viewflipper_signup_step2.xml
+++ b/app/src/main/res/layout/viewflipper_signup_step2.xml
@@ -9,9 +9,9 @@
         android:id="@+id/login_form"
         android:layout_width="fill_parent"
         android:layout_height="match_parent"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginLeft="@dimen/scroll_view_margin"
+        android:layout_marginRight="@dimen/scroll_view_margin"
+        android:layout_marginTop="@dimen/scroll_view_margin"
         android:background="@android:color/white"
         android:fillViewport="false">
 
@@ -20,10 +20,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingBottom="13dip"
-            android:paddingLeft="20dip"
-            android:paddingRight="20dip"
-            android:paddingTop="5dip">
+            android:paddingBottom="@dimen/layout_padding_bottom"
+            android:paddingLeft="@dimen/layout_padding_left_right"
+            android:paddingRight="@dimen/layout_padding_left_right"
+            android:paddingTop="@dimen/layout_padding_top">
 
             <ImageView
                 android:layout_width="wrap_content"
@@ -46,7 +46,7 @@
                     android:hint="@string/user_id"
                     android:inputType="text"
                     android:maxLines="1"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -66,7 +66,7 @@
                     android:hint="@string/password"
                     android:inputType="textPassword"
                     android:maxLines="1"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -86,7 +86,7 @@
                     android:hint="@string/confirm_password"
                     android:inputType="textPassword"
                     android:maxLines="1"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -112,7 +112,7 @@
                     android:inputType="text"
                     android:maxLines="1"
                     android:hint="@string/captcha_textview"
-                    android:minWidth="250dip"
+                    android:minWidth="@dimen/edittext_min_width"
                     android:scrollHorizontally="true"
                     android:textColor="@android:color/black" />
             </android.support.design.widget.TextInputLayout>
@@ -124,21 +124,21 @@
                 android:layout_marginTop="10dip"
                 android:gravity="left"
                 android:maxLines="2"
-                android:text="error message"
+                android:text="@string/error_message"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="#e10a0a"
+                android:textColor="@color/error_color"
                 android:textStyle="normal"
                 android:visibility="gone" />
             <Button
                 android:layout_weight="1"
-                android:layout_width="100dp"
-                android:layout_height="50dp"
-                android:text="Register"
-                android:layout_marginTop="20dp"
+                android:layout_width="@dimen/button_width"
+                android:layout_height="@dimen/button_height"
+                android:text="@string/register"
+                android:minHeight="@dimen/button_min_height"
+                android:layout_marginTop="@dimen/button_margin_top"
                 android:onClick="doNext"
-                android:textSize="15sp"
                 android:layout_gravity="right"
-                android:backgroundTint="#0077d9"
+                android:backgroundTint="@color/next_button_color"
                 android:textColor="@android:color/background_light" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/viewflipper_signup_step2.xml
+++ b/app/src/main/res/layout/viewflipper_signup_step2.xml
@@ -126,9 +126,20 @@
                 android:maxLines="2"
                 android:text="error message"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="@android:color/holo_red_light"
+                android:textColor="#e10a0a"
                 android:textStyle="normal"
                 android:visibility="gone" />
+            <Button
+                android:layout_weight="1"
+                android:layout_width="100dp"
+                android:layout_height="50dp"
+                android:text="Register"
+                android:layout_marginTop="20dp"
+                android:onClick="doNext"
+                android:textSize="15sp"
+                android:layout_gravity="right"
+                android:backgroundTint="#0077d9"
+                android:textColor="@android:color/background_light" />
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,6 @@
     <color name="primary_dark">#0077D9</color>
     <color name="primary_light">#0078D8</color>
     <color name="accent">#0078D8</color>
+    <color name="next_button_color">#0077d9</color>
+    <color name="error_color">#e10a0a</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,13 @@
 <resources>
     <dimen name="scroll_view_margin">10dp</dimen>
     <dimen name="textinput_margin">8dp</dimen>
+    <dimen name="head_text_size">20sp</dimen>
+    <dimen name="edittext_min_width">250dip</dimen>
+    <dimen name="button_min_height">50dp</dimen>
+    <dimen name="button_height">0dp</dimen>
+    <dimen name="button_width">100dp</dimen>
+    <dimen name="button_margin_top">20dp</dimen>
+    <dimen name="layout_padding_bottom">13dip</dimen>
+    <dimen name="layout_padding_left_right">20dip</dimen>
+    <dimen name="layout_padding_top">5dip</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,18 @@
     <string name="account_name">Account Name</string>
     <string name="cancel">Cancel</string>
     <string name="grant_permission_button">Authorize</string>
+    <string name="server_url">http://www.xwiki.org/xwiki</string>
+    <string name="login_sub_head">Login to your XWiki Instance.</string>
+    <string name="learn_more_dialog">Learn More</string>
+    <string name="log_in">Log in</string>
+    <string name="don_t_have_a_account">Don\'t Have a XWiki Account?</string>
+    <string name="create_one">Create One</string>
+    <string name="error_message">error message</string>
+    <string name="register">Register</string>
+    <string name="next">Next</string>
+    <string name="about_version">About Version</string>
+    <string name="version">Version 1.0</string>
+    <string name="complete">Complete</string>
 
 
     <!--select setting-->

--- a/authdemo/build.gradle
+++ b/authdemo/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "$rootProject.buildToolsVersion"
-
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "org.xwiki.android.authdemo"
         minSdkVersion 16
-        targetSdkVersion "$rootProject.targetSdkVersion"
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -20,11 +19,13 @@ android {
     lintOptions {
         abortOnError false
     }
+    productFlavors {
+    }
 }
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
     compile 'com.squareup.okhttp3:okhttp:3.3.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         jcenter()
         //for JakeWharton sdk automatically installing
         maven { url 'https://jitpack.io' }
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -18,6 +19,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://www.jitpack.io" }
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 27 13:19:26 CEST 2017
+#Fri Mar 02 18:27:50 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
The main changes made are as follows:-
*Replaced the next button with a new one with some design.
*Previous button was removed and the user can press back to navigate to previous screen.
*Added a new alert dialog containing some description if the user touches Learn More in server setup section.
*Modified the size of list view in the settings_sync screen to give space for complete button.
The modified layouts are given below.

![screenshot_2018-03-02-19-29-27-528_org xwiki android authenticator](https://user-images.githubusercontent.com/23225734/36904273-48ffe046-1e56-11e8-9306-157d0919d97f.png)
![screenshot_2018-03-02-19-29-38-706_org xwiki android authenticator](https://user-images.githubusercontent.com/23225734/36904274-493a6af4-1e56-11e8-8637-e251f0b77320.png)
![screenshot_2018-03-02-19-29-45-109_org xwiki android authenticator](https://user-images.githubusercontent.com/23225734/36904275-4974d388-1e56-11e8-95f7-23eff831acab.png)
![screenshot_2018-03-02-19-29-49-555_org xwiki android authenticator](https://user-images.githubusercontent.com/23225734/36904276-49b5aab6-1e56-11e8-9f97-f7ed5ae05439.png)
![screenshot_2018-03-02-19-30-22-188_org xwiki android authenticator](https://user-images.githubusercontent.com/23225734/36904277-49f250f6-1e56-11e8-99f4-8c0c55e69892.png)




