### PR TITLE
Build fix

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+-keep class com.google.oauth-client.** { *; }
+-keep class com.google.http-client.** { *; }
+-ignorewarnings


### PR DESCRIPTION
Recently I've added two libraries for OIDC and enabled minifyEnabled. This was causing the class not found exception while building. I've added 
-keep class com.google.oauth-client.** { *; }
-keep class com.google.http-client.** { *; }
-ignorewarnings

I've tested this build on Jenkins and it was successful.