### PR TITLE
ANDAUTH-65  Use WebView for opening registration link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".auth.RegistrationActivity"/>
+
         <activity
             android:name=".activities.GrantPermissionActivity"
             android:noHistory="true"

--- a/app/src/main/java/org/xwiki/android/sync/Constants.kt
+++ b/app/src/main/java/org/xwiki/android/sync/Constants.kt
@@ -52,7 +52,7 @@ const val XWIKI_DEFAULT_SERVER_ADDRESS = "https://www.xwiki.org/xwiki"
 
 const val ACCESS_TOKEN = "access_token"
 
-const val URL = "url"
+const val URL_FIELD = "url"
 
 /**
  * Auth token types

--- a/app/src/main/java/org/xwiki/android/sync/Constants.kt
+++ b/app/src/main/java/org/xwiki/android/sync/Constants.kt
@@ -52,6 +52,8 @@ const val XWIKI_DEFAULT_SERVER_ADDRESS = "https://www.xwiki.org/xwiki"
 
 const val ACCESS_TOKEN = "access_token"
 
+const val URL = "url"
+
 /**
  * Auth token types
  */

--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -270,7 +270,7 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
         }
 
         val regIntent = Intent(this, RegistrationActivity::class.java)
-        regIntent.putExtra("url", url)
+        regIntent.putExtra(URL, url)
         startActivity(regIntent)
     }
 

--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -268,10 +268,10 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
         } else {
             url += "/bin/view/XWiki/Registration"
         }
-        val intent = openLink(
-            url
-        )
-        startActivity(intent)
+
+        val regIntent = Intent(this, RegistrationActivity::class.java)
+        regIntent.putExtra("url", url)
+        startActivity(regIntent)
     }
 
     fun learnMore(view: View) {

--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -270,7 +270,7 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
         }
 
         val regIntent = Intent(this, RegistrationActivity::class.java)
-        regIntent.putExtra(URL, url)
+        regIntent.putExtra(URL_FIELD, url)
         startActivity(regIntent)
     }
 

--- a/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import org.xwiki.android.sync.R
-import org.xwiki.android.sync.utils.openLinkInWebView
+import org.xwiki.android.sync.utils.openLink
 
 class RegistrationActivity : AppCompatActivity() {
 
@@ -13,8 +13,6 @@ class RegistrationActivity : AppCompatActivity() {
         setContentView(R.layout.activity_registration)
         val webView = findViewById(R.id.webview) as WebView
         val url = intent.getStringExtra("url")
-        val intent = openLinkInWebView(
-                url, webView
-        )
+        val intent = webView.openLink(url)
     }
 }

--- a/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
@@ -12,7 +12,7 @@ class RegistrationActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registration)
-        val webView = findViewById(R.id.webview) as WebView
+        val webView = findViewById<WebView>(R.id.webview)
         val url = intent.getStringExtra(URL_FIELD)
         val intent = webView.openLink(url)
     }

--- a/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
@@ -13,7 +13,7 @@ class RegistrationActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registration)
         val webView = findViewById<WebView>(R.id.webview)
-        val url = intent.getStringExtra(URL_FIELD)
-        val intent = webView.openLink(url)
+        val url = intent.getStringExtra(URL_FIELD) ?: error("Url was not provided for registration WebView")
+        webView.openLink(url)
     }
 }

--- a/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import org.xwiki.android.sync.R
+import org.xwiki.android.sync.URL_FIELD
 import org.xwiki.android.sync.utils.openLink
 
 class RegistrationActivity : AppCompatActivity() {
@@ -12,7 +13,7 @@ class RegistrationActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registration)
         val webView = findViewById(R.id.webview) as WebView
-        val url = intent.getStringExtra("url")
+        val url = intent.getStringExtra(URL_FIELD)
         val intent = webView.openLink(url)
     }
 }

--- a/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/RegistrationActivity.kt
@@ -1,0 +1,20 @@
+package org.xwiki.android.sync.auth
+
+import android.os.Bundle
+import android.webkit.WebView
+import androidx.appcompat.app.AppCompatActivity
+import org.xwiki.android.sync.R
+import org.xwiki.android.sync.utils.openLinkInWebView
+
+class RegistrationActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_registration)
+        val webView = findViewById(R.id.webview) as WebView
+        val url = intent.getStringExtra("url")
+        val intent = openLinkInWebView(
+                url, webView
+        )
+    }
+}

--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -22,6 +22,12 @@ package org.xwiki.android.sync.utils
 import android.content.Intent
 import android.net.Uri
 import android.text.TextUtils
+import android.webkit.WebView
+import android.R
+import androidx.databinding.adapters.SeekBarBindingAdapter.setProgress
+import android.webkit.WebChromeClient
+
+
 
 /**
  * Check url (warning, url must start with "https://" or other protocol if you want not use
@@ -41,6 +47,29 @@ fun openLink(url: String): Intent {
     intent.action = Intent.ACTION_VIEW
     intent.data = Uri.parse(url)
     return intent
+}
+
+fun openLinkInWebView(url: String, webView: WebView)  {
+    var url = url
+    // if protocol isn't defined use http by default
+    if (!TextUtils.isEmpty(url) && !url.contains("://")) {
+        url = "http://$url"
+    }
+
+    webView.loadUrl(url)
+    webView.settings.javaScriptEnabled = true
+
+    /*webView.setWebViewClient(object : WebViewClient() {
+        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+            view.loadUrl(request.url.toString())
+            return false
+        }
+    })*/
+
+    /*val intent = Intent()
+    intent.action = Intent.ACTION_VIEW
+    intent.data = Uri.parse(url)
+    return intent*/
 }
 
 /**

--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -50,7 +50,7 @@ fun openLink(url: String): Intent {
 fun WebView.openLink(url: String)  {
     var url = url
     if (!TextUtils.isEmpty(url) && !url.contains("://")) {
-        url = "http://$url"
+        url = "https://$url"
     }
 
     this.loadUrl(url)

--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -58,18 +58,6 @@ fun openLinkInWebView(url: String, webView: WebView)  {
 
     webView.loadUrl(url)
     webView.settings.javaScriptEnabled = true
-
-    /*webView.setWebViewClient(object : WebViewClient() {
-        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-            view.loadUrl(request.url.toString())
-            return false
-        }
-    })*/
-
-    /*val intent = Intent()
-    intent.action = Intent.ACTION_VIEW
-    intent.data = Uri.parse(url)
-    return intent*/
 }
 
 /**

--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -49,15 +49,15 @@ fun openLink(url: String): Intent {
     return intent
 }
 
-fun openLinkInWebView(url: String, webView: WebView)  {
+fun WebView.openLink(url: String)  {
     var url = url
     // if protocol isn't defined use http by default
     if (!TextUtils.isEmpty(url) && !url.contains("://")) {
         url = "http://$url"
     }
 
-    webView.loadUrl(url)
-    webView.settings.javaScriptEnabled = true
+    this.loadUrl(url)
+    this.settings.javaScriptEnabled = true
 }
 
 /**

--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -27,8 +27,6 @@ import android.R
 import androidx.databinding.adapters.SeekBarBindingAdapter.setProgress
 import android.webkit.WebChromeClient
 
-
-
 /**
  * Check url (warning, url must start with "https://" or other protocol if you want not use
  * http) and open browser or other application which can open that url.
@@ -51,7 +49,6 @@ fun openLink(url: String): Intent {
 
 fun WebView.openLink(url: String)  {
     var url = url
-    // if protocol isn't defined use http by default
     if (!TextUtils.isEmpty(url) && !url.contains("://")) {
         url = "http://$url"
     }

--- a/app/src/main/res/layout/activity_registration.xml
+++ b/app/src/main/res/layout/activity_registration.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".auth.RegistrationActivity">
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>


### PR DESCRIPTION
Implemented WebView so that the registration page opens in the app itself instead of an external browser, when the user clicks on 'Create One' for creating an account.