### PR TITLE
ANDAUTH-75 Show error when empty or wrong URL is submitted in server address

### DIFF
--- a/app/src/main/java/org/xwiki/android/sync/activities/BaseViewFlipper.kt
+++ b/app/src/main/java/org/xwiki/android/sync/activities/BaseViewFlipper.kt
@@ -59,8 +59,10 @@ abstract class BaseViewFlipper(protected var mActivity: AuthenticatorActivity, p
 
     /**
      * Must be called when current flipper page must be slided to next.
+     *
+     * @return true if it is possible to go to the next step. Returns false otherwise
      */
-    abstract fun doNext()
+    abstract fun doNext(): Boolean
 
     /**
      * Must be called when current flipper page must be slided to previous.

--- a/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
+++ b/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
@@ -49,7 +49,9 @@ class SettingServerIpViewFlipper(activity: AuthenticatorActivity, contentRootVie
     override fun doNext() {
         checkInput().let {
             if (it != null) {
+                val position = mActivity.binding.viewFlipper.displayedChild
                 mActivity.serverUrl = it
+                mActivity.showViewFlipper(position + 1)
             }
         }
     }
@@ -68,8 +70,8 @@ class SettingServerIpViewFlipper(activity: AuthenticatorActivity, contentRootVie
         val serverAddress = serverEditText.text.toString()
 
         if (TextUtils.isEmpty(serverAddress)) {
-            serverEditText.error = mContext.getString(R.string.error_field_required)
             serverEditText.requestFocus()
+            serverEditText.error = mContext.getString(R.string.error_field_required)
             return null
         } else {
             try {

--- a/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
+++ b/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
@@ -46,13 +46,9 @@ class SettingServerIpViewFlipper(activity: AuthenticatorActivity, contentRootVie
     /**
      * Check typed server address and call sign in if all is ok.
      */
-    override fun doNext() {
-        checkInput() ?.also {
-            val position = mActivity.binding.viewFlipper.displayedChild
-            mActivity.serverUrl = it
-            mActivity.showViewFlipper(position + 1)
-        }
-    }
+    override fun doNext() = checkInput() ?.also {
+        mActivity.serverUrl = it
+    } != null
 
     /**
      * Do nothing (Setting server IP is first operation of adding account.

--- a/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
+++ b/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
@@ -47,12 +47,10 @@ class SettingServerIpViewFlipper(activity: AuthenticatorActivity, contentRootVie
      * Check typed server address and call sign in if all is ok.
      */
     override fun doNext() {
-        checkInput().let {
-            if (it != null) {
-                val position = mActivity.binding.viewFlipper.displayedChild
-                mActivity.serverUrl = it
-                mActivity.showViewFlipper(position + 1)
-            }
+        checkInput() ?.also {
+            val position = mActivity.binding.viewFlipper.displayedChild
+            mActivity.serverUrl = it
+            mActivity.showViewFlipper(position + 1)
         }
     }
 

--- a/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
+++ b/app/src/main/java/org/xwiki/android/sync/activities/SettingServerIpViewFlipper.kt
@@ -69,21 +69,20 @@ class SettingServerIpViewFlipper(activity: AuthenticatorActivity, contentRootVie
         serverEditText.error = null
         val serverAddress = serverEditText.text.toString()
 
-        if (TextUtils.isEmpty(serverAddress)) {
-            serverEditText.requestFocus()
+        return if (TextUtils.isEmpty(serverAddress)) {
             serverEditText.error = mContext.getString(R.string.error_field_required)
-            return null
+            serverEditText.requestFocus()
+            null
         } else {
             try {
                 URL(serverAddress)
-                return serverAddress
+                serverAddress
             } catch (e: MalformedURLException) {
                 Log.e(SettingServerIpViewFlipper::class.java.simpleName, "Wrong url", e)
                 serverEditText.error = mContext.getString(R.string.error_invalid_server)
                 serverEditText.requestFocus()
-                return null
+                null
             }
-
         }
     }
 }

--- a/app/src/main/java/org/xwiki/android/sync/activities/SignInViewFlipper.kt
+++ b/app/src/main/java/org/xwiki/android/sync/activities/SignInViewFlipper.kt
@@ -121,7 +121,7 @@ class SignInViewFlipper(
     /**
      * Calling when user push "login".
      */
-    override fun doNext() {}
+    override fun doNext() = true
 
     /**
      * Return to setting server ip address, calling by pressing "back".

--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -218,9 +218,12 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
     fun doNext(view: View) {
         val position = binding.viewFlipper.displayedChild
         chooseAnimation(true)
-        flippers[position]?.doNext()
-        if (position + 1 >= orderOfFlippers.size) {
-            finish()
+        if (flippers[position] ?.doNext() == true) {
+            if (position + 1 >= orderOfFlippers.size) {
+                finish()
+            } else {
+                showViewFlipper(position + 1)
+            }
         }
     }
 

--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -222,7 +222,6 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
         if (position + 1 >= orderOfFlippers.size) {
             finish()
         }
-        showViewFlipper(position + 1)
     }
 
     /**


### PR DESCRIPTION
Prevent user from proceeding to the login page with a blank server address. Now error message will also be shown when user enters an invalid URL. Earlier the sign in page was getting opened without validating the URL.