### PR TITLE
ANDAUTH-77 Use https by default instead of http

### DIFF
--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -35,7 +35,7 @@ fun openLink(url: String): Intent {
     var url = url
     // if protocol isn't defined use http by default
     if (!TextUtils.isEmpty(url) && !url.contains("://")) {
-        url = "http://$url"
+        url = "https://$url"
     }
 
     val intent = Intent()

--- a/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
+++ b/app/src/main/java/org/xwiki/android/sync/utils/IntentUtils.kt
@@ -33,7 +33,7 @@ import android.webkit.WebView
  */
 fun openLink(url: String): Intent {
     var url = url
-    // if protocol isn't defined use http by default
+    // if protocol isn't defined use https by default
     if (!TextUtils.isEmpty(url) && !url.contains("://")) {
         url = "https://$url"
     }


### PR DESCRIPTION
Now, **https** will be used instead of **http** while opening links through the app.