### PR TITLE
ANDAUTH-79 Display proper message on going back from OIDCActivity

### DIFF
--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -489,7 +489,7 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if(requestCode == REQUEST_NEW_ACCOUNT) {
+        if(requestCode == REQUEST_NEW_ACCOUNT && resultCode != Activity.RESULT_CANCELED) {
             val accessToken = data ?.extras ?.get(ACCESS_TOKEN) ?.toString()
             if (accessToken.isNullOrEmpty()) {
                 Toast.makeText(this, "Something went wrong. Please try again.", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
+++ b/app/src/main/java/org/xwiki/android/sync/auth/AuthenticatorActivity.kt
@@ -489,7 +489,11 @@ class AuthenticatorActivity : AccountAuthenticatorActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if(requestCode == REQUEST_NEW_ACCOUNT && resultCode != Activity.RESULT_CANCELED) {
+        if(requestCode == REQUEST_NEW_ACCOUNT) {
+            if(resultCode == Activity.RESULT_CANCELED) {
+                Toast.makeText(this, "Authorization via OIDC was cancelled.", Toast.LENGTH_SHORT).show()
+                return
+            }
             val accessToken = data ?.extras ?.get(ACCESS_TOKEN) ?.toString()
             if (accessToken.isNullOrEmpty()) {
                 Toast.makeText(this, "Something went wrong. Please try again.", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
Now, false error message would not appear on going back from OIDCActivity to Sign In page.